### PR TITLE
pib: lib/Makefile.in: Use `find -name` instead of `grep`

### DIFF
--- a/iafse/pib/trunk/lib/Makefile.in
+++ b/iafse/pib/trunk/lib/Makefile.in
@@ -6,7 +6,7 @@ INSTALL = @INSTALL@
 
 NAME = pib
 
-TARGET_FILES = $(shell find .|grep '\.scm')
+TARGET_FILES = $(shell find . -name '*.scm')
 
 
 GENERATED = 


### PR DESCRIPTION
The previous script was mistakenly trying to install any files that had ".scm" anywhere in their names. We don't want, e.g. "pib.scm.orig", to be installed just because it happens to be in ./lib